### PR TITLE
Add CSS cache busting with hashed filenames

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ meta.siteName }}{% if page.url != '/' %} | {{ title }} {% endif %}</title>
-  <link rel="stylesheet" href="{{ '/css/style.css' | url }}">
+  <link rel="stylesheet" href="{{ '/css/style.css' | cacheBust | url }}">
   {% if page.url == '/coverage/' %}
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>


### PR DESCRIPTION
## Summary
Implement reliable CSS cache busting using content-hashed filenames to ensure browsers always load the latest styles after deployments.

## Problem
CSS files can be cached by browsers, CDNs, and proxies, causing users to see stale styles after deployments. Query parameter cache busting (`?v=hash`) is not always reliable as some CDNs and proxies ignore query parameters.

## Solution
- Generate MD5 hash from CSS file content at build time
- Copy CSS file with hash embedded in filename: `style-{hash}.css`
- Use Eleventy filter to reference the hashed filename in templates
- Hash automatically updates whenever CSS content changes

## Example
Before: `/css/style.css`  
After: `/css/style-a8ef8ea2fb.css`

## Technical Details
- Uses Node.js built-in `crypto` and `fs` modules (no new dependencies)
- Hooks into Eleventy's `eleventy.before` event to generate hash
- Simple 30-line implementation focused on single CSS file
- Easy to extend for JavaScript files if needed in the future

## Benefits
- More reliable than query parameters for CDN/proxy caching
- Forces cache invalidation on every CSS change
- No cache issues after deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)